### PR TITLE
remove error flags, change include location

### DIFF
--- a/ExampleCodes/Basic/HeatEquation_EX4_C/Exec/GNUmakefile
+++ b/ExampleCodes/Basic/HeatEquation_EX4_C/Exec/GNUmakefile
@@ -12,9 +12,8 @@ include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 include ../Source/Make.package
 VPATH_LOCATIONS  += ../Source
-INCLUDE_LOCATIONS += ./Source
+INCLUDE_LOCATIONS += ../Source
 
-CPPFLAGS += -Werror -Wsuggest-override
 
 ifeq ($(USE_SUNDIALS),TRUE)
 SUNDIALS_ROOT ?= $(TOP)/../../../../../sundials/instdir
@@ -35,3 +34,4 @@ endif
 include $(AMREX_HOME)/Src/Base/Make.package
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.rules
+


### PR DESCRIPTION
Can we remove the `-Werror -Wsuggest-override` flags in the makefile? Do they offer something special for coding with SUNDIALS? Also, i think the `./Source` is missing a second dot.  -- Please correct me if I am mistaken on either of these. 